### PR TITLE
feat: navbar + prelim profile page + jwt token

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -1,6 +1,7 @@
 import Head from 'next/head';
 import React from 'react';
 import {capitalize} from '../utils';
+import Navbar from './Navbar';
 
 export interface LayoutProps {
   children: React.ReactNode;
@@ -34,6 +35,7 @@ function Layout(props: LayoutProps): JSX.Element {
         <title>{title}</title>
         <link rel="icon" href="/favicon.ico" />
       </Head>
+      <Navbar />
       <main id={props.id}>
         {props.children}
       </main>

--- a/components/Link.tsx
+++ b/components/Link.tsx
@@ -1,0 +1,15 @@
+import NextLink from 'next/link';
+import React from 'react';
+
+export interface LinkProps {
+  href: string;
+  children: string;
+}
+
+export default function Link({href, children}: LinkProps): JSX.Element {
+  return (
+    <NextLink href={href}>
+      <a>{children}</a>
+    </NextLink>
+  );
+}

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+import styles from '../styles/Navbar.module.scss';
+import Link from './Link';
+import SpotifyAuth from './SpotifyAuth';
+
+export default function Navbar(): JSX.Element {
+  return (
+    <div id={styles.navbar}>
+      <div id={styles['logo-container']}>
+        <Link href='/'>Aurgy</Link>
+      </div>
+      <div id={styles['links-container']}>
+        <Link href='/me'>me?</Link>
+        <Link href='/lobby'>lobbys</Link>
+        <SpotifyAuth />
+      </div>
+    </div>
+  );
+}

--- a/components/SpotifyAuth.tsx
+++ b/components/SpotifyAuth.tsx
@@ -8,7 +8,13 @@ import {
 } from '../utils';
 
 export default function SpotifyAuth(): JSX.Element {
+  const {isAuthenticated} = useContext(AppContext);
+  return isAuthenticated ? <LogOut /> : <LogIn />;
+}
+
+function LogIn(): JSX.Element {
   const router = useRouter();
+
   const login = async () => {
     const storage = window.localStorage;
     const { state, authenticationUrl, code_verifier } = await authenticate();
@@ -18,14 +24,13 @@ export default function SpotifyAuth(): JSX.Element {
   };
 
   return (
-    <button onClick={login}>Log in to Spotify</button>
+    <button onClick={login}>LOG IN</button>
   );
 }
 
-export function Logout(): JSX.Element {
+function LogOut(): JSX.Element {
   const {signOut} = useContext(AppContext);
-
   return (
-    <button onClick={signOut}>Logout</button>
+    <button onClick={signOut}>LOGOUT</button>
   );
 }

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -2,6 +2,7 @@ import {AppProps} from 'next/app';
 import React, { createContext, useEffect, useState } from 'react';
 import { AURGY_USER_DATA} from '../utils';
 import '../styles/globals.scss';
+import { authCookie } from '../utils/aurgy';
 import { indexCookie } from '../utils/cookies';
 import { IUserData } from '../utils/user-data';
 
@@ -19,7 +20,7 @@ export const AppContext = createContext<IAppContext>({
   signOut: () => null,
 });
 
-function MyApp({ Component, pageProps }: AppProps): React.ReactNode {
+function MyApp({ Component, pageProps }: AppProps): JSX.Element {
   const [ userData, setUserData ] = useState<IUserData | null>(null);
   const [ isAuthenticated, setIsAuthenticated ] = useState(false);
 
@@ -29,15 +30,8 @@ function MyApp({ Component, pageProps }: AppProps): React.ReactNode {
 
     const signin = async () => {
       const token = indexCookie('token');
-      if (!token) return;
-      const res = await window.fetch('https://daddy.creativelabsucla.com/me', {
-        method: 'GET',
-        headers: {
-          'Authorization': `Bearer ${token}`,
-          'Content-Type': 'application/json',
-        },
-      });
-      const data = await res.json();
+      if (!token || token === 'undefined') return;
+      const data = await authCookie(token);
       setUserData(data);
     };
 
@@ -55,7 +49,7 @@ function MyApp({ Component, pageProps }: AppProps): React.ReactNode {
   }, [userData]);
 
   const signOut = () => {
-    document.cookie = undefined;
+    document.cookie = 'token=undefined';
     setUserData(null);
 
     // make doubling work here but making sure this is set to null

--- a/pages/callback.tsx
+++ b/pages/callback.tsx
@@ -2,13 +2,15 @@ import { useRouter } from 'next/router';
 import React, {useContext, useEffect} from 'react';
 import Layout from '../components/Layout';
 import {AppContext} from '../pages/_app';
+import styles from '../styles/Callback.module.scss';
 import {
   getUrlPath,
   SPOTIFY_STATE,
   fetchSpotifyTokens,
 } from '../utils';
+import { signIn } from '../utils/aurgy';
 
-export default function SpotifyCallback(): React.ReactNode {
+export default function SpotifyCallback(): JSX.Element {
   const {setUserData} = useContext(AppContext);
   const router = useRouter();
   useEffect(() => {
@@ -17,24 +19,17 @@ export default function SpotifyCallback(): React.ReactNode {
     if (!code || !state || state !== storage.getItem(SPOTIFY_STATE)) return;
     const redirect = async () => {
       const {refreshToken} = await fetchSpotifyTokens(code, storage);
-      const res = await window.fetch('https://daddy.creativelabsucla.com/me', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ refreshToken }),
-      });
-      const data = await res.json();
+      const data = await signIn(refreshToken);
       document.cookie = `token=${data.jwt}`;
       setUserData(data);
-      void router.push(getUrlPath());
+      void router.push(getUrlPath() + '/me');
     };
     void redirect();
   }, [router]);
 
   return (
     <Layout>
-      <div>
+      <div id={styles['callback-container']}>
         LOGGING YOU INTO AURGY
       </div>
     </Layout>

--- a/pages/lobby.tsx
+++ b/pages/lobby.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
 import Layout from '../components/Layout';
 
-export default function Home(): JSX.Element {
-
+export default function Lobbies(): JSX.Element {
   return (
     <Layout>
-      <h1>AURGY</h1>
+      <h1>Here is where all lobbies are located</h1>
     </Layout>
   );
 }

--- a/pages/me.tsx
+++ b/pages/me.tsx
@@ -1,0 +1,56 @@
+import React, { useContext } from 'react';
+import Layout from '../components/Layout';
+import SpotifyAuth from '../components/SpotifyAuth';
+
+import styles from '../styles/Me.module.scss';
+import { deleteAccount } from '../utils/aurgy';
+import { indexCookie } from '../utils/cookies';
+import { AppContext } from './_app';
+
+export default function Me(): JSX.Element {
+  const {userData, isAuthenticated, signOut} = useContext(AppContext);
+
+  if (!isAuthenticated) {
+    return (
+      <Layout>
+        <div id={styles['login-container']}>
+          <SpotifyAuth />
+        </div>
+      </Layout>
+    );
+  }
+
+  const content = {
+    'Remaining Lobbies': 3,
+    'Account Type': userData.accountType,
+  };
+
+  const onClick = () => {
+    const token = indexCookie('token');
+    if (!token || token === 'undefined') return;
+    void deleteAccount(token);
+    signOut();
+  };
+
+  return (
+    <Layout id={styles.main}>
+      <div id={styles['me-container']}>
+        <h2>{userData.name}</h2>
+        {Object.entries(content).map(([key, value]) => {
+          return (
+            <div className={styles.row} key={key}>
+              <p className={styles.label}>{key}</p>
+              <p className={styles.value}>{value}</p>
+            </div>
+          );
+        })}
+        <div className={styles.row}>
+          <SpotifyAuth />
+          <button onClick={onClick}>
+            Delete Account
+          </button>
+        </div>
+      </div>
+    </Layout>
+  );
+}

--- a/styles/Callback.module.scss
+++ b/styles/Callback.module.scss
@@ -1,0 +1,5 @@
+@use 'mixins.module' as mixin;
+
+#callback-container {
+  @include mixin.centerElements;
+}

--- a/styles/Me.module.scss
+++ b/styles/Me.module.scss
@@ -1,0 +1,31 @@
+@use 'variables.module' as *;
+@use 'mixins.module' as mixin;
+
+#main {
+  padding: 0 $horizontal-margins;
+  width: calc(100% - #{$horizontal-margins} * 2);
+}
+
+#me-container {
+  max-width: $content-max-width;
+  margin: $vertical-padding auto;
+
+  h2 {
+    margin-bottom: 40px;
+  }
+}
+
+#login-container {
+  @include mixin.centerElements;
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+
+  .value {
+    color: map-get($colors, 'white-50');
+  }
+}

--- a/styles/Navbar.module.scss
+++ b/styles/Navbar.module.scss
@@ -1,0 +1,32 @@
+@use 'variables.module' as *;
+
+#navbar,
+#logo-container,
+#links-container {
+  display: flex;
+  align-items: center;
+}
+
+#navbar {
+  justify-content: space-between;
+  min-height: 128px;
+  width: 100%;
+}
+
+#logo-container {
+  margin-left: $horizontal-margins;
+  font: $body-small-fancy;
+}
+
+#links-container {
+  margin-right: $horizontal-margins;
+  font: $body-small-bold;
+
+  * {
+    margin-left: 32px;
+  }
+
+  :nth-child(1) {
+    margin-left: 0;
+  }
+}

--- a/styles/_mixins.module.scss
+++ b/styles/_mixins.module.scss
@@ -1,0 +1,9 @@
+@use 'variables.module' as *;
+
+@mixin centerElements {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: calc(100vh - 2 * #{$vertical-padding});
+  margin-bottom: $vertical-padding;
+}

--- a/styles/_variables.module.scss
+++ b/styles/_variables.module.scss
@@ -7,16 +7,17 @@ $header-2: normal 400 48px 'Audiowide', sans-serif;
 $body-xlarge: normal 600 32px 'Montserrat', sans-serif;
 $body-large: normal 600 28px 'Montserrat', sans-serif;
 $body-large-lite: normal 400 20px 'Montserrat', sans-serif;
-$body: normal 600 24px 'Montserrat', sans-serif;
-$body-small-bold: normal 600 20px 'Montserrat', sans-serif;
+$body: normal 600 20px 'Montserrat', sans-serif;
+$body-small-bold: normal 600 16px 'Montserrat', sans-serif;
 $body-small-fancy: normal 400 20px 'Audiowide', sans-serif;
 
-$button-text: normal 600 18px 'Monteserrat', sans-serif;
+$button-text: normal 400 16px 'Monteserrat', sans-serif;
 
 // COLORS
 $colors: (
   'black': #000,
   'white': #fff,
+  'white-50': #fff7,
   neonPink: #f89df6,
   neonPinkShadow: #b900b5,
 );
@@ -25,6 +26,8 @@ $colors: (
 $vertical-padding: 128px;
 $content-max-width: 850px;
 $button-horizontal-padding: 24px;
+
+$horizontal-margins: 64px;
 
 // Export to JS
 :export {

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -1,8 +1,13 @@
 @use 'variables.module' as *;
 
-body {
-  padding: 0;
+* {
+  text-transform: uppercase;
   margin: 0;
+}
+
+body {
+  overflow-x: hidden;
+  padding: 0;
   font: $body;
   background-color: map-get($colors, 'black');
 }
@@ -29,6 +34,21 @@ h4 {
 
 p {
   line-height: 1.6em;
+}
+
+button {
+  background-color: transparent;
+  font: $button-text;
+  color: map-get($colors, 'white');
+
+  // SIZING
+  padding: 4px $button-horizontal-padding;
+  min-height: 32px;
+
+  // BORDER
+  border: 2px solid map-get($colors, 'white');
+  border-radius: 32px;
+  cursor: pointer;
 }
 
 a {

--- a/utils/aurgy.ts
+++ b/utils/aurgy.ts
@@ -1,6 +1,6 @@
 import { IUserData } from './user-data';
 
-const URL = 'http://158.101.44.113:3000';
+const URL = 'https://daddy.creativelabsucla.com';
 
 export async function signIn(refreshToken: string): Promise<IUserData | null> {
   const res = await window.fetch(URL + '/me', {

--- a/utils/aurgy.ts
+++ b/utils/aurgy.ts
@@ -1,0 +1,40 @@
+import { IUserData } from './user-data';
+
+const URL = 'http://158.101.44.113:3000';
+
+export async function signIn(refreshToken: string): Promise<IUserData | null> {
+  const res = await window.fetch(URL + '/me', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ refreshToken }),
+  });
+  if (!res.ok) return null;
+  const data = await res.json();
+  return data;
+}
+
+export async function authCookie(jwt: string): Promise<IUserData | null> {
+  const res = await window.fetch(URL + '/me', {
+    method: 'GET',
+    headers: {
+      'Authorization': `Bearer ${jwt}`,
+      'Content-Type': 'application/json',
+    },
+  });
+  if (!res.ok) return null;
+  const data = await res.json();
+  return data;
+}
+
+export async function deleteAccount(jwt: string): Promise<void> {
+  void window.fetch(URL + '/me', {
+    method: 'DELETE',
+    headers: {
+      'Authorization': `Bearer ${jwt}`,
+      'Content-Type': 'application/json',
+    },
+  });
+}
+

--- a/utils/user-data.ts
+++ b/utils/user-data.ts
@@ -1,1 +1,8 @@
-export type IUserData = Record<string, any>
+export type IUserData = {
+  readonly accountType: 'premium' | 'free';
+  readonly name: string;
+  readonly images: string[];
+  readonly country: string;
+  readonly id: string;
+  readonly jwt: string;
+}


### PR DESCRIPTION
**Features**
* Created a `Navbar` component
* Implemented routing to `/`, `/me`, `/lobby` (still missing the `/lobby/[id].tsx` or `/lobby?id={lobbyId}` page)
* Added `Navbar` to `Layout` so it should appear on every screen
* Properly implement jwt token (this should be good now!)
* Preliminary implementation of profile page

**Todo** (in another pr)
- [ ] Add active class name to show which page we are on (highlight/neon light the current page in navbar)