### PR TITLE
feat: start linking with backend

### DIFF
--- a/components/Modal.tsx
+++ b/components/Modal.tsx
@@ -6,20 +6,29 @@ interface ModalProps {
   show: boolean;
   onCancel: () => void;
   onConfirm: () => void;
+  showFooter?: boolean;
   children: React.ReactNode;
 }
 
-function Modal({title, show, onCancel, onConfirm, children}: ModalProps): JSX.Element {
+function Modal({
+  title,
+  show,
+  onCancel,
+  onConfirm,
+  showFooter = true,
+  children,
+}: ModalProps): JSX.Element {
   return (
     <>
       <div id={styles.overlay} className={show ? styles.show : ''} onClick={onCancel} />
       <div id={styles.modal}>
         <div id={styles['modal-header']}>{title}</div>
         {children}
-        <div id={styles['modal-footer']}>
-          <button onClick={onCancel}>NAH</button>
-          <button onClick={onConfirm}>GO</button>
-        </div>
+        {showFooter &&
+                    <div id={styles['modal-footer']}>
+                      <button onClick={onCancel}>NAH</button>
+                      <button onClick={onConfirm}>GO</button>
+                    </div>}
       </div>
     </>
   );

--- a/components/Modal.tsx
+++ b/components/Modal.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styles from '../styles/modal.module.scss';
 
-export interface BaseModalProps {
+export interface ModalProps {
   title: string;
   onCancel: () => void;
   onConfirm: () => void;
@@ -9,19 +9,14 @@ export interface BaseModalProps {
   children: React.ReactNode;
 }
 
-interface ModalProps extends BaseModalProps {
-  show: boolean;
-}
-
 function Modal({
   title,
-  show,
   onCancel,
   onConfirm,
   showFooter = true,
   children,
 }: ModalProps): JSX.Element {
-  const overlayClass = `${styles.overlay} ${show ? styles.show : ''}`;
+  const overlayClass = `${styles.overlay} ${styles.show}`;
 
   return (
     <>

--- a/components/Modal.tsx
+++ b/components/Modal.tsx
@@ -1,13 +1,16 @@
 import React from 'react';
 import styles from '../styles/modal.module.scss';
 
-interface ModalProps {
+export interface BaseModalProps {
   title: string;
-  show: boolean;
   onCancel: () => void;
   onConfirm: () => void;
   showFooter?: boolean;
   children: React.ReactNode;
+}
+
+interface ModalProps extends BaseModalProps {
+  show: boolean;
 }
 
 function Modal({
@@ -18,14 +21,16 @@ function Modal({
   showFooter = true,
   children,
 }: ModalProps): JSX.Element {
+  const overlayClass = `${styles.overlay} ${show ? styles.show : ''}`;
+
   return (
     <>
-      <div id={styles.overlay} className={show ? styles.show : ''} onClick={onCancel} />
-      <div id={styles.modal}>
-        <div id={styles['modal-header']}>{title}</div>
+      <div className={overlayClass} onClick={onCancel} />
+      <div className={styles.modal}>
+        <div>{title}</div>
         {children}
         {showFooter &&
-                    <div id={styles['modal-footer']}>
+                    <div className={styles['modal-footer']}>
                       <button onClick={onCancel}>NAH</button>
                       <button onClick={onConfirm}>GO</button>
                     </div>}

--- a/components/Modal.tsx
+++ b/components/Modal.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React from 'react';
 import styles from '../styles/modal.module.scss';
 
 interface ModalProps {

--- a/components/Modal.tsx
+++ b/components/Modal.tsx
@@ -1,0 +1,28 @@
+import React, {useState} from 'react';
+import styles from '../styles/modal.module.scss';
+
+interface ModalProps {
+  title: string;
+  show: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+  children: React.ReactNode;
+}
+
+function Modal({title, show, onCancel, onConfirm, children}: ModalProps): JSX.Element {
+  return (
+    <>
+      <div id={styles.overlay} className={show ? styles.show : ''} onClick={onCancel} />
+      <div id={styles.modal}>
+        <div id={styles['modal-header']}>{title}</div>
+        {children}
+        <div id={styles['modal-footer']}>
+          <button onClick={onCancel}>NAH</button>
+          <button onClick={onConfirm}>GO</button>
+        </div>
+      </div>
+    </>
+  );
+}
+
+export default Modal;

--- a/components/nameplate/AnimatedShape.tsx
+++ b/components/nameplate/AnimatedShape.tsx
@@ -3,12 +3,19 @@ import Shape, {Polygon} from '../../components/Shape';
 import styles from '../../styles/lobby.module.scss';
 import {makeNameplateTimeline} from '../../utils';
 import useTimelineControls from '../../utils/animations/useTimelineControls';
+import Tooltip from '../Tooltip';
+
+export interface ButtonProps {
+  text: string;
+  callback: () => void;
+}
 
 export interface BaseAnimatedProps {
   shape: Polygon;
   highlight?: boolean;
   expanded?: boolean;
   animate?: boolean;
+  buttonOptions?: ButtonProps;
 }
 
 interface AnimatedShapeProps extends BaseAnimatedProps {
@@ -20,6 +27,7 @@ function AnimatedShape({
   shortText,
   longText,
   shape,
+  buttonOptions,
   highlight = false,
   expanded = false,
   animate = true,
@@ -44,6 +52,11 @@ function AnimatedShape({
 
   const className = `${styles.nameplate} ${highlight ? styles.highlight : ''} ${expanded ? styles.expanded : ''}`;
 
+  const optionalButton =
+        <div className={styles['nameplate-button']} onClick={buttonOptions?.callback}>
+            X
+        </div>;
+
   return (
     <div
       className={className}
@@ -54,7 +67,10 @@ function AnimatedShape({
         <Shape polygon={shape} ref={polygonRef} />
       </div>
       <div className={styles['nameplate-short']} ref={shortLabelRef}>{shortText}</div>
-      <div className={styles['nameplate-long']} ref={longLabelRef}>{longText}</div>
+      <div className={styles['nameplate-long']} ref={longLabelRef}>
+        <div className={styles['nameplate-text']}>{longText}</div>
+        {buttonOptions && optionalButton}
+      </div>
     </div >
   );
 }

--- a/components/nameplate/AnimatedShape.tsx
+++ b/components/nameplate/AnimatedShape.tsx
@@ -3,7 +3,6 @@ import Shape, {Polygon} from '../../components/Shape';
 import styles from '../../styles/lobby.module.scss';
 import {makeNameplateTimeline} from '../../utils';
 import useTimelineControls from '../../utils/animations/useTimelineControls';
-import Tooltip from '../Tooltip';
 
 export interface ButtonProps {
   text: string;

--- a/components/nameplate/AnimatedShape.tsx
+++ b/components/nameplate/AnimatedShape.tsx
@@ -1,8 +1,8 @@
 import React, {useEffect, useRef} from 'react';
 import Shape, {Polygon} from '../../components/Shape';
-import styles from '../../styles/lobby.module.scss';
+import useTimelineControls from '../../hooks/useTimelineControls';
+import styles from '../../styles/nameplate.module.scss';
 import {makeNameplateTimeline} from '../../utils';
-import useTimelineControls from '../../utils/animations/useTimelineControls';
 
 export interface ButtonProps {
   text: string;

--- a/components/nameplate/Nameplate.tsx
+++ b/components/nameplate/Nameplate.tsx
@@ -11,6 +11,7 @@ function Nameplate({
   shape,
   highlight = false,
   expanded = false,
+  buttonOptions,
 }: NameplateProps): JSX.Element {
   return (
     <AnimatedShape
@@ -19,6 +20,7 @@ function Nameplate({
       shape={shape}
       highlight={highlight}
       expanded={expanded}
+      buttonOptions={buttonOptions}
     />
   );
 }

--- a/components/nameplate/NameplateGroup.tsx
+++ b/components/nameplate/NameplateGroup.tsx
@@ -1,30 +1,35 @@
 import React from 'react';
+import {ButtonProps} from './AnimatedShape';
 import Nameplate, {NameplateProps, Overflow} from './Nameplate';
 
 export interface NameplateGroupProps {
   names: NameplateProps[];
   expandCurrentUser?: boolean;
   limit?: number;
+  buttonOptions?: ButtonProps;
 }
 
 function NameplateGroup({
   names,
   expandCurrentUser = false,
   limit: propLimit,
+  buttonOptions,
 }: NameplateGroupProps): JSX.Element {
   const limit = propLimit ?? names.length;
 
   return (
     <>
-      {names.slice(0, limit).map(passedProps =>
-        <Nameplate
+      {names.slice(0, limit).map(passedProps => {
+        const isCurrentUser = passedProps.shape === 'circle';
+        return <Nameplate
           name={passedProps.name}
           shape={passedProps.shape}
-          highlight={passedProps.shape === 'circle'}
-          expanded={passedProps.shape === 'circle' && expandCurrentUser}
           key={`${passedProps.name}-${passedProps.shape}`}
-        />,
-      )}
+          highlight={isCurrentUser}
+          expanded={isCurrentUser && expandCurrentUser}
+          buttonOptions={!isCurrentUser && buttonOptions}
+        />;
+      })}
       {names.length > limit &&
                 <Overflow
                   items={names.slice(limit).map(props => props.name)}

--- a/hooks/useModal.tsx
+++ b/hooks/useModal.tsx
@@ -1,0 +1,29 @@
+import React, {useState, useCallback} from 'react';
+import Modal, {BaseModalProps} from '../components/Modal';
+
+type Return = [
+    Modal: (props: BaseModalProps) => JSX.Element,
+    showModal: () => void,
+    hideModal: () => void
+];
+
+function useModal(): Return {
+  const [show, setShow] = useState(false);
+
+  const ModalWrapper = useCallback(
+    ({children, ...props}: BaseModalProps) => {
+      return (
+        <Modal {...props} show={show}>
+          {children}
+        </Modal>
+      );
+    }, [show],
+  );
+
+  const showModal = () => setShow(true);
+  const hideModal = () => setShow(false);
+
+  return [ModalWrapper, showModal, hideModal];
+}
+
+export default useModal;

--- a/hooks/useModal.tsx
+++ b/hooks/useModal.tsx
@@ -1,8 +1,8 @@
 import React, {useState, useCallback} from 'react';
-import Modal, {BaseModalProps} from '../components/Modal';
+import Modal, {ModalProps} from '../components/Modal';
 
 type Return = [
-    Modal: (props: BaseModalProps) => JSX.Element,
+    Modal: (props: ModalProps) => JSX.Element,
     showModal: () => void,
     hideModal: () => void
 ];
@@ -11,9 +11,9 @@ function useModal(): Return {
   const [show, setShow] = useState(false);
 
   const ModalWrapper = useCallback(
-    ({children, ...props}: BaseModalProps) => {
-      return (
-        <Modal {...props} show={show}>
+    ({children, ...props}: ModalProps) => {
+      return !show ? null : (
+        <Modal {...props}>
           {children}
         </Modal>
       );

--- a/hooks/useTimelineControls.tsx
+++ b/hooks/useTimelineControls.tsx
@@ -3,7 +3,7 @@ import {useCallback} from 'react';
 import {
   playTimeline,
   reverseTimeline,
-} from './timeline';
+} from '../utils/animations/timeline';
 
 interface Props {
   tlRef: React.MutableRefObject<AnimeTimelineInstance>,

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,10 +1,10 @@
 import {AppProps} from 'next/app';
-import React, { createContext, useEffect, useState } from 'react';
-import { AURGY_USER_DATA} from '../utils';
+import React, {createContext, useEffect, useState} from 'react';
+import {AURGY_USER_DATA} from '../utils';
 import '../styles/globals.scss';
-import { authCookie } from '../utils/aurgy';
-import { indexCookie } from '../utils/cookies';
-import { IUserData } from '../utils/user-data';
+import {authCookie} from '../utils/aurgy';
+import {indexCookie} from '../utils/cookies';
+import {IUserData} from '../utils/user-data';
 
 export interface IAppContext {
   userData: IUserData | null,
@@ -20,9 +20,9 @@ export const AppContext = createContext<IAppContext>({
   signOut: () => null,
 });
 
-function MyApp({ Component, pageProps }: AppProps): JSX.Element {
-  const [ userData, setUserData ] = useState<IUserData | null>(null);
-  const [ isAuthenticated, setIsAuthenticated ] = useState(false);
+function MyApp({Component, pageProps}: AppProps): JSX.Element {
+  const [userData, setUserData] = useState<IUserData | null>(null);
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
 
   useEffect(() => {
     const storage = window.localStorage;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,13 +1,13 @@
 import React, {useEffect, useState} from 'react';
 import Layout from '../components/Layout';
 import Link from '../components/Link';
-import Modal from '../components/Modal';
+import useModal from '../hooks/useModal';
 import {fetchAllLobbies, createLobby, fetchLobbyById} from '../utils/aurgy';
 import {indexCookie} from '../utils/cookies';
 import {ILobbyData} from '../utils/lobby-data';
 
 export default function Home(): JSX.Element {
-  const [showModal, setShowModal] = useState(false);
+  const [Modal, showModal, hideModal] = useModal();
   const [lobbies, setLobbies] = useState<ILobbyData[]>([]);
   const [name, setName] = useState('');
   const [theme, setTheme] = useState('');
@@ -31,7 +31,7 @@ export default function Home(): JSX.Element {
     const data = await createLobby({lobbyName: name, theme}, token);
     const lobby = await fetchLobbyById(data.id, token);
     setLobbies(lobbies.concat(lobby));
-    setShowModal(false);
+    hideModal();
   }
 
   return (
@@ -50,11 +50,10 @@ export default function Home(): JSX.Element {
           </div>,
         )}
       </div>
-      <button onClick={() => setShowModal(true)}>CREATE LOBBY</button>
+      <button onClick={() => showModal()}>CREATE LOBBY</button>
       <Modal
         title="CREATE LOBBY"
-        show={showModal}
-        onCancel={() => setShowModal(false)}
+        onCancel={() => hideModal()}
         onConfirm={onConfirm}
       >
         <input type="text" placeholder="NAME" value={name} onChange={(e) => setName(e.target.value)} />

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,11 +1,65 @@
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 import Layout from '../components/Layout';
+import Modal from '../components/Modal';
+import {fetchAllLobbies, createLobby, fetchLobbyById} from '../utils/aurgy';
+import {indexCookie} from '../utils/cookies';
+import {ILobbyData} from '../utils/lobby-data';
 
 export default function Home(): JSX.Element {
+  const [showModal, setShowModal] = useState(false);
+  const [lobbies, setLobbies] = useState<ILobbyData[]>([]);
+  const [name, setName] = useState('');
+  const [theme, setTheme] = useState('');
+
+  useEffect(() => {
+    async function loadData() {
+      const token = indexCookie('token');
+      if (!token || token === 'undefined') return;
+
+      const ids = await fetchAllLobbies(token);
+      const lobbyData = await Promise.all(ids.lobbies.map(id => fetchLobbyById(id, token)));
+      setLobbies(lobbyData);
+    }
+    void loadData();
+  }, []);
+
+  async function onConfirm() {
+    const token = indexCookie('token');
+    if (!token || token === 'undefined') return;
+
+    const data = await createLobby({lobbyName: name, theme}, token);
+    const lobby = await fetchLobbyById(data.id, token);
+    setLobbies(lobbies.concat(lobby));
+    setShowModal(false);
+  }
 
   return (
     <Layout>
       <h1>AURGY</h1>
+
+      <h3>lobbies:</h3>
+      <div>
+        {lobbies && lobbies.map(lobby =>
+          <div key={lobby.id}>
+            <div>id: {lobby.id}</div>
+            <div>managerId: {lobby.managerId}</div>
+            <div>theme: {lobby.theme}</div>
+            <div>name: {lobby.name}</div>
+            <div>participants: {lobby.participants.join(', ')}</div>
+            <br />
+          </div>,
+        )}
+      </div>
+      <button onClick={() => setShowModal(true)}>CREATE LOBBY</button>
+      <Modal
+        title="CREATE LOBBY"
+        show={showModal}
+        onCancel={() => setShowModal(false)}
+        onConfirm={onConfirm}
+      >
+        <input type="text" placeholder="NAME" value={name} onChange={(e) => setName(e.target.value)} />
+        <input type="text" placeholder="THEME NAME" value={theme} onChange={(e) => setTheme(e.target.value)} />
+      </Modal>
     </Layout>
   );
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,5 +1,6 @@
 import React, {useEffect, useState} from 'react';
 import Layout from '../components/Layout';
+import Link from '../components/Link';
 import Modal from '../components/Modal';
 import {fetchAllLobbies, createLobby, fetchLobbyById} from '../utils/aurgy';
 import {indexCookie} from '../utils/cookies';
@@ -41,10 +42,11 @@ export default function Home(): JSX.Element {
       <div>
         {lobbies && lobbies.map(lobby =>
           <div key={lobby.id}>
+            <Link href={'/lobby?id=' + lobby.id}>GO TO LOBBY</Link>
+            <div>name: {lobby.name}</div>
+            <div>theme: {lobby.theme}</div>
             <div>id: {lobby.id}</div>
             <div>managerId: {lobby.managerId}</div>
-            <div>theme: {lobby.theme}</div>
-            <div>name: {lobby.name}</div>
             <div>participants: {lobby.participants.join(', ')}</div>
             <br />
           </div>,

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -46,8 +46,6 @@ export default function Home(): JSX.Element {
             <div>name: {lobby.name}</div>
             <div>theme: {lobby.theme}</div>
             <div>id: {lobby.id}</div>
-            <div>managerId: {lobby.managerId}</div>
-            <div>participants: {lobby.participants.join(', ')}</div>
             <br />
           </div>,
         )}

--- a/pages/lobby.tsx
+++ b/pages/lobby.tsx
@@ -64,6 +64,7 @@ const SAMPLE_PLAYLIST_DATA = [
 function Lobby(): JSX.Element {
   const {query} = useRouter();
   const [lobbyData, setLobbyData] = useState<ILobbyData>(null);
+  const [loaded, setLoaded] = useState(false);
 
   useEffect(() => {
     async function loadData() {
@@ -72,14 +73,17 @@ function Lobby(): JSX.Element {
 
       const data = await fetchLobbyById(query.id as string, token);
       setLobbyData(data);
+      setLoaded(true);
     }
     void loadData();
   }, []);
 
-  if (lobbyData == null) {
+  if (!loaded || lobbyData == null) {
     return (
       <Layout>
-        <div className={styles.container}>Invalid lobby.</div>
+        <div className={`${styles.container} ${styles['loading-text']}`}>
+          {!loaded ? 'LOADING...' : 'INVALID LOBBY.'}
+        </div>
       </Layout>
     );
   }

--- a/pages/lobby.tsx
+++ b/pages/lobby.tsx
@@ -1,6 +1,7 @@
 import {useRouter} from 'next/router';
 import React, {useEffect, useState} from 'react';
 import Layout from '../components/Layout';
+import Modal from '../components/Modal';
 import {NameplateProps} from '../components/nameplate/Nameplate';
 import NameplateGroup from '../components/nameplate/NameplateGroup';
 import PlaylistVisual from '../components/PlaylistVisual';
@@ -65,6 +66,7 @@ function Lobby(): JSX.Element {
   const {query} = useRouter();
   const [lobbyData, setLobbyData] = useState<ILobbyData>(null);
   const [loaded, setLoaded] = useState(false);
+  const [showModal, setShowModal] = useState(false);
 
   useEffect(() => {
     async function loadData() {
@@ -81,7 +83,7 @@ function Lobby(): JSX.Element {
   if (!loaded || lobbyData == null) {
     return (
       <Layout>
-        <div className={`${styles.container} ${styles['loading-text']}`}>
+        <div className={`${styles['center-text']}`}>
           {!loaded ? 'LOADING...' : 'INVALID LOBBY.'}
         </div>
       </Layout>
@@ -101,7 +103,7 @@ function Lobby(): JSX.Element {
             text: 'DELETE USER',
             callback: () => null,
           }} />
-          <button>invite</button>
+          <button onClick={() => setShowModal(true)}>invite</button>
         </div>
 
         <div id={styles.playlist}>
@@ -118,6 +120,17 @@ function Lobby(): JSX.Element {
           ))}
         </div>
       </div>
+
+      <Modal
+        title="SEND THIS LINK"
+        show={showModal}
+        onCancel={() => setShowModal(false)}
+        onConfirm={() => null}
+        showFooter={false}
+      >
+        <div>https://cl.com/me</div>
+        <button>COPY TO CLIPBOARD</button>
+      </Modal>
     </Layout>
   );
 }

--- a/pages/lobby.tsx
+++ b/pages/lobby.tsx
@@ -58,6 +58,7 @@ const SAMPLE_PLAYLIST_DATA = [
 ];
 
 function Lobby(): JSX.Element {
+
   return (
     <Layout>
       <div className={styles.container}>
@@ -67,7 +68,10 @@ function Lobby(): JSX.Element {
         />
 
         <div id={styles.userbar} data-tip={'test'}>
-          <NameplateGroup names={USERS} expandCurrentUser={true} />
+          <NameplateGroup names={USERS} expandCurrentUser={true} buttonOptions={{
+            text: 'wow',
+            callback: () => null,
+          }} />
           <button>invite</button>
         </div>
 

--- a/pages/lobby.tsx
+++ b/pages/lobby.tsx
@@ -1,10 +1,14 @@
-import React from 'react';
+import {useRouter} from 'next/router';
+import React, {useEffect, useState} from 'react';
 import Layout from '../components/Layout';
 import {NameplateProps} from '../components/nameplate/Nameplate';
 import NameplateGroup from '../components/nameplate/NameplateGroup';
 import PlaylistVisual from '../components/PlaylistVisual';
 import Tooltip from '../components/Tooltip';
 import styles from '../styles/lobby.module.scss';
+import {fetchLobbyById} from '../utils/aurgy';
+import {indexCookie} from '../utils/cookies';
+import {ILobbyData} from '../utils/lobby-data';
 
 const USERS: NameplateProps[] = [
   {
@@ -58,18 +62,39 @@ const SAMPLE_PLAYLIST_DATA = [
 ];
 
 function Lobby(): JSX.Element {
+  const {query} = useRouter();
+  const [lobbyData, setLobbyData] = useState<ILobbyData>(null);
+
+  useEffect(() => {
+    async function loadData() {
+      const token = indexCookie('token');
+      if (!token || token === 'undefined' || query?.id == null) return;
+
+      const data = await fetchLobbyById(query.id as string, token);
+      setLobbyData(data);
+    }
+    void loadData();
+  }, []);
+
+  if (lobbyData == null) {
+    return (
+      <Layout>
+        <div className={styles.container}>Invalid lobby.</div>
+      </Layout>
+    );
+  }
 
   return (
     <Layout>
       <div className={styles.container}>
         <PlaylistVisual
-          title="CREATIVE SLAPS"
-          subtitle="PEANUT BUTTER JAM"
+          title={lobbyData.name}
+          subtitle={lobbyData.theme}
         />
 
         <div id={styles.userbar} data-tip={'test'}>
           <NameplateGroup names={USERS} expandCurrentUser={true} buttonOptions={{
-            text: 'wow',
+            text: 'DELETE USER',
             callback: () => null,
           }} />
           <button>invite</button>

--- a/styles/_variables.module.scss
+++ b/styles/_variables.module.scss
@@ -16,6 +16,7 @@ $button-text: normal 400 16px 'Monteserrat', sans-serif;
 // COLORS
 $colors: (
   'black': #000,
+  'black-50': #0007,
   'white': #fff,
   'white-50': #fff7,
   neonPink: #f89df6,

--- a/styles/_variables.module.scss
+++ b/styles/_variables.module.scss
@@ -16,9 +16,10 @@ $button-text: normal 400 16px 'Monteserrat', sans-serif;
 // COLORS
 $colors: (
   'black': #000,
-  'black-50': #0007,
+  'black-75': #000c,
   'white': #fff,
   'white-50': #fff7,
+  'white-25': #fff3,
   neonPink: #f89df6,
   neonPinkShadow: #b900b5,
 );

--- a/styles/lobby.module.scss
+++ b/styles/lobby.module.scss
@@ -1,71 +1,8 @@
 @use 'variables.module' as *;
 @use 'mixins.module' as *;
 
-// NAMEPLATE
-
-$nameplate-size: 40;
-$nameplate-width-min: 9px;
-$nameplate-width-max: 140px;
-$nameplate-padding-min: 0 10px;
-$nameplate-padding-max: 0 25px;
-
-.nameplate {
-  margin-right: 20px;
-  font: $body-small-fancy;
-  text-align: center;
-  z-index: 1;
-
-  .nameplate-container {
-    width: #{$nameplate-size}px;
-    height: #{$nameplate-size}px;
-  }
-
-  .nameplate-short {
-    width: #{$nameplate-size}px;
-    margin-top: #{-$nameplate-size}px;
-    line-height: #{$nameplate-size}px;
-  }
-
-  .nameplate-long {
-    max-width: $nameplate-width-min;
-    display: flex;
-    height: #{$nameplate-size - 6}px; // size - 2 * border-width
-    line-height: #{$nameplate-size - 6}px;
-    margin-top: #{-$nameplate-size}px;
-    padding: $nameplate-padding-min;
-    opacity: 0;
-    border: 3px solid #fff;
-    border-radius: #{$nameplate-size - 6}px;
-  }
-
-  .nameplate-text {
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-
-  .nameplate-button {
-    margin-left: 10px;
-    cursor: pointer;
-  }
-
-  &.expanded .nameplate-long {
-    max-width: $nameplate-width-max !important;
-    opacity: 1 !important;
-    padding: $nameplate-padding-max !important;
-  }
-
-  &.expanded .nameplate-short,
-  &.expanded .nameplate-container {
-    opacity: 0 !important;
-  }
-
-  &.highlight svg {
-    fill: map-get($colors, 'white-50');
-  }
-
-  &.highlight .nameplate-long {
-    background-color: map-get($colors, 'white-50');
-  }
+:import('nameplate.module.scss') {
+  user-nameplate: nameplate;
 }
 
 // PLAYLIST VISUALIZATION + USERS BAR
@@ -145,11 +82,11 @@ $visual-circle-size: 310px;
       align-items: center;
       margin-left: auto;
 
-      .nameplate {
+      .user-nameplate {
         margin-right: 15px;
       }
 
-      .nameplate:last-of-type {
+      .user-nameplate:last-of-type {
         margin-right: 0;
       }
     }
@@ -212,9 +149,4 @@ $visual-circle-size: 310px;
   defaultVisualWidth: $max-visual-width;
   defaultVisualHeight: $desktop-visual-height;
   visualCircleSize: $visual-circle-size;
-  nameplateSize: $nameplate-size;
-  nameplateWidthMin: $nameplate-width-min;
-  nameplateWidthMax: $nameplate-width-max;
-  nameplatePaddingMin: $nameplate-padding-min;
-  nameplatePaddingMax: $nameplate-padding-max;
 }

--- a/styles/lobby.module.scss
+++ b/styles/lobby.module.scss
@@ -77,6 +77,10 @@ $nameplate-padding-max: 0 25px;
   align-items: center;
 }
 
+.loading-text {
+  margin-top: calc(50vh - 128px);
+}
+
 $mobile-visual-height: 300px;
 $desktop-visual-height: 650px;
 

--- a/styles/lobby.module.scss
+++ b/styles/lobby.module.scss
@@ -71,14 +71,13 @@ $nameplate-padding-max: 0 25px;
 // PLAYLIST VISUALIZATION + USERS BAR
 
 .container {
-  height: 100vh;
   display: flex;
   flex-direction: column;
   align-items: center;
 }
 
-.loading-text {
-  margin-top: calc(50vh - 128px);
+.center-text {
+  @include centerElements;
 }
 
 $mobile-visual-height: 300px;

--- a/styles/lobby.module.scss
+++ b/styles/lobby.module.scss
@@ -1,10 +1,6 @@
 @use 'variables.module' as *;
 @use 'mixins.module' as *;
 
-:import('nameplate.module.scss') {
-  user-nameplate: nameplate;
-}
-
 // PLAYLIST VISUALIZATION + USERS BAR
 
 .container {
@@ -149,4 +145,8 @@ $visual-circle-size: 310px;
   defaultVisualWidth: $max-visual-width;
   defaultVisualHeight: $desktop-visual-height;
   visualCircleSize: $visual-circle-size;
+}
+
+:import('nameplate.module.scss') {
+  user-nameplate: nameplate;
 }

--- a/styles/lobby.module.scss
+++ b/styles/lobby.module.scss
@@ -5,7 +5,7 @@
 
 $nameplate-size: 40;
 $nameplate-width-min: 9px;
-$nameplate-width-max: 110px;
+$nameplate-width-max: 140px;
 $nameplate-padding-min: 0 10px;
 $nameplate-padding-max: 0 25px;
 
@@ -28,6 +28,7 @@ $nameplate-padding-max: 0 25px;
 
   .nameplate-long {
     max-width: $nameplate-width-min;
+    display: flex;
     height: #{$nameplate-size - 6}px; // size - 2 * border-width
     line-height: #{$nameplate-size - 6}px;
     margin-top: #{-$nameplate-size}px;
@@ -35,13 +36,21 @@ $nameplate-padding-max: 0 25px;
     opacity: 0;
     border: 3px solid #fff;
     border-radius: #{$nameplate-size - 6}px;
+  }
+
+  .nameplate-text {
     overflow: hidden;
     text-overflow: ellipsis;
   }
 
+  .nameplate-button {
+    margin-left: 10px;
+    cursor: pointer;
+  }
+
   &.expanded .nameplate-long {
-    opacity: 1 !important;
     max-width: $nameplate-width-max !important;
+    opacity: 1 !important;
     padding: $nameplate-padding-max !important;
   }
 

--- a/styles/modal.module.scss
+++ b/styles/modal.module.scss
@@ -1,36 +1,40 @@
 @use 'variables.module' as *;
 
 #modal {
-  position: absolute;
+  position: fixed;
   top: 0;
   left: 0;
   margin-left: calc((100vw - 350px) / 2);
-  margin-top: calc((100vh - 150px) / 2);
+  margin-top: calc((100vh - 200px) / 2);
   width: 350px;
-  height: 150px;
-  padding: 20px 30px;
-  color: map-get($colors, 'black');
+  height: 200px;
   background-color: map-get($colors, 'white');
+  background-color: transparent;
   display: none;
   flex-direction: column;
   justify-content: space-between;
+  z-index: 2;
 
   input {
-    width: 330px;
-    padding: 5px 10px;
-    border: 1px solid #ddd;
-    border-radius: 4px;
+    width: 320px;
+    padding: 5px 15px;
+    outline: none;
+    border: none;
+    border-radius: 15px;
+    color: map-get($colors, 'white');
+    background-color: map-get($colors, 'white-25');
   }
 }
 
 #overlay {
-  position: absolute;
+  position: fixed;
   top: 0;
   left: 0;
   width: 100vw;
   height: 100vh;
-  background-color: map-get($colors, 'black-50');
+  background-color: map-get($colors, 'black-75');
   display: none;
+  z-index: 1;
 
   &.show {
     display: block;
@@ -41,18 +45,10 @@
   }
 }
 
-#modal-header {
-  color: map-get($colors, 'black');
-  padding-bottom: 10px;
-  border-bottom: 2px solid black;
-}
-
 #modal-footer {
   align-self: flex-end;
 
   button {
-    color: black;
-    border-color: black;
     margin-left: 10px;
   }
 }

--- a/styles/modal.module.scss
+++ b/styles/modal.module.scss
@@ -1,6 +1,6 @@
 @use 'variables.module' as *;
 
-#modal {
+.modal {
   position: fixed;
   top: 0;
   left: 0;
@@ -13,7 +13,7 @@
   display: none;
   flex-direction: column;
   justify-content: space-between;
-  z-index: 2;
+  z-index: 100;
 
   input {
     width: 320px;
@@ -26,7 +26,7 @@
   }
 }
 
-#overlay {
+.overlay {
   position: fixed;
   top: 0;
   left: 0;
@@ -34,18 +34,18 @@
   height: 100vh;
   background-color: map-get($colors, 'black-75');
   display: none;
-  z-index: 1;
+  z-index: 99;
 
   &.show {
     display: block;
   }
 
-  &.show ~ #modal {
+  &.show ~ .modal {
     display: flex;
   }
 }
 
-#modal-footer {
+.modal-footer {
   align-self: flex-end;
 
   button {

--- a/styles/modal.module.scss
+++ b/styles/modal.module.scss
@@ -40,6 +40,7 @@
     display: flex;
   }
 }
+
 #modal-header {
   color: map-get($colors, 'black');
   padding-bottom: 10px;
@@ -48,6 +49,7 @@
 
 #modal-footer {
   align-self: flex-end;
+
   button {
     color: black;
     border-color: black;

--- a/styles/modal.module.scss
+++ b/styles/modal.module.scss
@@ -1,0 +1,56 @@
+@use 'variables.module' as *;
+
+#modal {
+  position: absolute;
+  top: 0;
+  left: 0;
+  margin-left: calc((100vw - 350px) / 2);
+  margin-top: calc((100vh - 150px) / 2);
+  width: 350px;
+  height: 150px;
+  padding: 20px 30px;
+  color: map-get($colors, 'black');
+  background-color: map-get($colors, 'white');
+  display: none;
+  flex-direction: column;
+  justify-content: space-between;
+
+  input {
+    width: 330px;
+    padding: 5px 10px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+  }
+}
+
+#overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: map-get($colors, 'black-50');
+  display: none;
+
+  &.show {
+    display: block;
+  }
+
+  &.show ~ #modal {
+    display: flex;
+  }
+}
+#modal-header {
+  color: map-get($colors, 'black');
+  padding-bottom: 10px;
+  border-bottom: 2px solid black;
+}
+
+#modal-footer {
+  align-self: flex-end;
+  button {
+    color: black;
+    border-color: black;
+    margin-left: 10px;
+  }
+}

--- a/styles/nameplate.module.scss
+++ b/styles/nameplate.module.scss
@@ -1,0 +1,77 @@
+@use 'variables.module' as *;
+@use 'mixins.module' as *;
+
+// NAMEPLATE
+
+$nameplate-size: 40;
+$nameplate-width-min: 9px;
+$nameplate-width-max: 140px;
+$nameplate-padding-min: 0 10px;
+$nameplate-padding-max: 0 25px;
+
+.nameplate {
+  margin-right: 20px;
+  font: $body-small-fancy;
+  text-align: center;
+  z-index: 1;
+
+  .nameplate-container {
+    width: #{$nameplate-size}px;
+    height: #{$nameplate-size}px;
+  }
+
+  .nameplate-short {
+    width: #{$nameplate-size}px;
+    margin-top: #{-$nameplate-size}px;
+    line-height: #{$nameplate-size}px;
+  }
+
+  .nameplate-long {
+    max-width: $nameplate-width-min;
+    display: flex;
+    height: #{$nameplate-size - 6}px; // size - 2 * border-width
+    line-height: #{$nameplate-size - 6}px;
+    margin-top: #{-$nameplate-size}px;
+    padding: $nameplate-padding-min;
+    opacity: 0;
+    border: 3px solid #fff;
+    border-radius: #{$nameplate-size - 6}px;
+  }
+
+  .nameplate-text {
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .nameplate-button {
+    margin-left: 10px;
+    cursor: pointer;
+  }
+
+  &.expanded .nameplate-long {
+    max-width: $nameplate-width-max !important;
+    opacity: 1 !important;
+    padding: $nameplate-padding-max !important;
+  }
+
+  &.expanded .nameplate-short,
+  &.expanded .nameplate-container {
+    opacity: 0 !important;
+  }
+
+  &.highlight svg {
+    fill: map-get($colors, 'white-50');
+  }
+
+  &.highlight .nameplate-long {
+    background-color: map-get($colors, 'white-50');
+  }
+}
+
+:export {
+  nameplateSize: $nameplate-size;
+  nameplateWidthMin: $nameplate-width-min;
+  nameplateWidthMax: $nameplate-width-max;
+  nameplatePaddingMin: $nameplate-padding-min;
+  nameplatePaddingMax: $nameplate-padding-max;
+}

--- a/utils/animations/timeline.ts
+++ b/utils/animations/timeline.ts
@@ -1,6 +1,6 @@
 import anime, {AnimeTimelineInstance} from 'animejs';
 import {Polygon} from '../../components/Shape';
-import styles from '../../styles/lobby.module.scss';
+import styles from '../../styles/nameplate.module.scss';
 import tipStyles from '../../styles/tooltip.module.scss';
 import {PARAM_DEFAULTS, fadeElement, morphPolygon} from './animations';
 

--- a/utils/aurgy.ts
+++ b/utils/aurgy.ts
@@ -1,6 +1,12 @@
-import { IUserData } from './user-data';
+import {ILobbyCreationData, ILobbiesData, ILobbyData} from './lobby-data';
+import {IUserData} from './user-data';
 
-const URL = 'https://daddy.creativelabsucla.com';
+// const URL = 'https://daddy.creativelabsucla.com';
+const URL = 'http://158.101.44.113:3000';
+
+/**
+ * USER SERVICES
+ */
 
 export async function signIn(refreshToken: string): Promise<IUserData | null> {
   const res = await window.fetch(URL + '/me', {
@@ -8,7 +14,7 @@ export async function signIn(refreshToken: string): Promise<IUserData | null> {
     headers: {
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify({ refreshToken }),
+    body: JSON.stringify({refreshToken}),
   });
   if (!res.ok) return null;
   const data = await res.json();
@@ -38,3 +44,52 @@ export async function deleteAccount(jwt: string): Promise<void> {
   });
 }
 
+/**
+ * LOBBY SERVICES
+ */
+
+interface LobbyParams {
+  lobbyName: string;
+  theme: string;
+}
+
+export async function createLobby(params: LobbyParams, jwt: string)
+  : Promise<ILobbyCreationData | null> {
+  const res = await window.fetch(URL + '/lobby', {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${jwt}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(params),
+  });
+  if (!res.ok) return null;
+  const data = await res.json();
+  return data;
+}
+
+export async function fetchAllLobbies(jwt: string): Promise<ILobbiesData | null> {
+  const res = await window.fetch(URL + '/lobby', {
+    method: 'GET',
+    headers: {
+      'Authorization': `Bearer ${jwt}`,
+      'Content-Type': 'application/json',
+    },
+  });
+  if (!res.ok) return null;
+  const data = await res.json();
+  return data;
+}
+
+export async function fetchLobbyById(id: string, jwt: string): Promise<ILobbyData | null> {
+  const res = await window.fetch(URL + '/lobby/' + id, {
+    method: 'GET',
+    headers: {
+      'Authorization': `Bearer ${jwt}`,
+      'Content-Type': 'application/json',
+    },
+  });
+  if (!res.ok) return null;
+  const data = await res.json();
+  return data;
+}

--- a/utils/aurgy.ts
+++ b/utils/aurgy.ts
@@ -1,8 +1,7 @@
 import {ILobbyCreationData, ILobbiesData, ILobbyData} from './lobby-data';
 import {IUserData} from './user-data';
 
-// const URL = 'https://daddy.creativelabsucla.com';
-const URL = 'http://158.101.44.113:3000';
+const URL = 'https://daddy.creativelabsucla.com';
 
 /**
  * USER SERVICES

--- a/utils/lobby-data.ts
+++ b/utils/lobby-data.ts
@@ -1,0 +1,16 @@
+export type ILobbyCreationData = {
+  readonly name: string;
+  readonly id: string;
+}
+
+export type ILobbiesData = {
+  readonly lobbies: string[];
+}
+
+export type ILobbyData = {
+  readonly id: string;
+  readonly managerId: string;
+  readonly name: string;
+  readonly participants: string[];
+  readonly theme: string;
+};

--- a/utils/spotify.ts
+++ b/utils/spotify.ts
@@ -4,10 +4,8 @@ import {
   SPOTIFY_SCOPE,
   SPOTIFY_CODE_VERIFIER,
 } from './constants';
-import {generateChallenge, generateRandomString, IChallenge} from './pkce';
+import { generateChallenge, generateRandomString, IChallenge } from './pkce';
 import {getUrlPath} from './url';
-
-const SPOTIFY_API = 'https://api.spotify.com/v1';
 
 export interface IAuthentication extends IChallenge {
   readonly state: string;
@@ -16,19 +14,19 @@ export interface IAuthentication extends IChallenge {
 
 export async function authenticate(): Promise<IAuthentication> {
   const state = generateRandomString(16);
-  const {code_challenge, code_verifier} = await generateChallenge();
+  const { code_challenge, code_verifier } = await generateChallenge();
   const authenticationUrl = 'https://accounts.spotify.com/authorize?' +
-        querystring.stringify({
-          response_type: 'code',
-          client_id: CLIENT_ID,
-          scope: SPOTIFY_SCOPE,
-          redirect_uri: getUrlPath() + '/callback',
-          state: state,
-          code_challenge,
-          code_challenge_method: 'S256',
-        });
+    querystring.stringify({
+      response_type: 'code',
+      client_id: CLIENT_ID,
+      scope: SPOTIFY_SCOPE,
+      redirect_uri: getUrlPath() + '/callback',
+      state: state,
+      code_challenge,
+      code_challenge_method: 'S256',
+    });
 
-  return {state, authenticationUrl, code_challenge, code_verifier};
+  return { state, authenticationUrl, code_challenge, code_verifier };
 }
 
 interface SpotifyTokens {
@@ -52,17 +50,4 @@ export async function fetchSpotifyTokens(code: string | string[], storage: Stora
   });
   const {access_token, refresh_token} = await response.json();
   return {accessToken: access_token, refreshToken: refresh_token};
-}
-
-export async function getPlaylistSongs(id: string) {
-  const res = await window.fetch(SPOTIFY_API + '/playlists/' + id + '/tracks', {
-    method: 'GET',
-    headers: {
-      // 'Authorization': `Bearer ${jwt}`,
-      'Content-Type': 'application/json',
-    },
-  });
-  if (!res.ok) return null;
-  const data = await res.json();
-  return data;
 }

--- a/utils/spotify.ts
+++ b/utils/spotify.ts
@@ -4,8 +4,10 @@ import {
   SPOTIFY_SCOPE,
   SPOTIFY_CODE_VERIFIER,
 } from './constants';
-import { generateChallenge, generateRandomString, IChallenge } from './pkce';
+import {generateChallenge, generateRandomString, IChallenge} from './pkce';
 import {getUrlPath} from './url';
+
+const SPOTIFY_API = 'https://api.spotify.com/v1';
 
 export interface IAuthentication extends IChallenge {
   readonly state: string;
@@ -14,19 +16,19 @@ export interface IAuthentication extends IChallenge {
 
 export async function authenticate(): Promise<IAuthentication> {
   const state = generateRandomString(16);
-  const { code_challenge, code_verifier } = await generateChallenge();
+  const {code_challenge, code_verifier} = await generateChallenge();
   const authenticationUrl = 'https://accounts.spotify.com/authorize?' +
-    querystring.stringify({
-      response_type: 'code',
-      client_id: CLIENT_ID,
-      scope: SPOTIFY_SCOPE,
-      redirect_uri: getUrlPath() + '/callback',
-      state: state,
-      code_challenge,
-      code_challenge_method: 'S256',
-    });
+        querystring.stringify({
+          response_type: 'code',
+          client_id: CLIENT_ID,
+          scope: SPOTIFY_SCOPE,
+          redirect_uri: getUrlPath() + '/callback',
+          state: state,
+          code_challenge,
+          code_challenge_method: 'S256',
+        });
 
-  return { state, authenticationUrl, code_challenge, code_verifier };
+  return {state, authenticationUrl, code_challenge, code_verifier};
 }
 
 interface SpotifyTokens {
@@ -50,4 +52,17 @@ export async function fetchSpotifyTokens(code: string | string[], storage: Stora
   });
   const {access_token, refresh_token} = await response.json();
   return {accessToken: access_token, refreshToken: refresh_token};
+}
+
+export async function getPlaylistSongs(id: string) {
+  const res = await window.fetch(SPOTIFY_API + '/playlists/' + id + '/tracks', {
+    method: 'GET',
+    headers: {
+      // 'Authorization': `Bearer ${jwt}`,
+      'Content-Type': 'application/json',
+    },
+  });
+  if (!res.ok) return null;
+  const data = await res.json();
+  return data;
 }


### PR DESCRIPTION
## Changes
- added an X button in the user nameplates that we can use to remove users from a lobby
- added a modal on the home page to create a lobby (styling very WIP)
- initial hooking up with backend:
  - POST `/lobby` with modal
  - GET `/lobby` to show which lobbies a user belongs to (temporarily just list everything on home page)
  - GET `/lobby/id` for lobby name and theme

## TODO

- once #11 is merged in, can remove the temporary stuff on the home page
- environment variable for dev vs. production backend address
- add some kind of tooltip or modal for removing a user

## Status on integrating backend routes
- [X] POST `/lobby` 
- [X] GET `/lobby` - API could return lobby names and themes, not just ids, to avoid second round of requests
- [ ] POST `/lobby/:id`
- [ ] PATCH `/lobby/:id`
- [X] GET `/lobby/:id` - API needs to fetch the actual playlist songs, also return participant names as well as their IDs
- [ ] DELETE `/lobby/:id`
- [ ] DELETE `/lobby/:id/user/:id`